### PR TITLE
update light_the_torch usage

### DIFF
--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -1,6 +1,5 @@
 from genericpath import exists
 import os
-from torch._C import Node
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 import logging

--- a/Modules/Scripted/Home/HomeLib/dependency_installer.py
+++ b/Modules/Scripted/Home/HomeLib/dependency_installer.py
@@ -1,12 +1,15 @@
 import slicer, qt, importlib, functools
 
-def pip_install_with_cursor(*args, **kwargs):
-  """Just slicer.util.pip_install but with a busy cursor while it executes."""
-  qt.QApplication.setOverrideCursor(qt.Qt.BusyCursor)
-  try:
-    slicer.util.pip_install(*args, **kwargs)
-  finally:
-    qt.QApplication.restoreOverrideCursor()
+
+class BusyCursor:
+    """Context manager for showing a busy cursor. Ensures that cursor reverts to normal in case of an exception."""
+
+    def __enter__(self):
+        qt.QApplication.setOverrideCursor(qt.Qt.BusyCursor)
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        qt.QApplication.restoreOverrideCursor()
+        return False
 
 
 def check_and_install_package(module_names, pip_install_name, pre_install_hook = None):
@@ -32,9 +35,8 @@ def check_and_install_package(module_names, pip_install_name, pre_install_hook =
     if wantInstall:
       if pre_install_hook is not None:
         pre_install_hook()
-      qt.QApplication.setOverrideCursor(qt.Qt.BusyCursor)
-      pip_install_with_cursor(pip_install_name)
-      qt.QApplication.restoreOverrideCursor()
+      with BusyCursor():
+        slicer.util.pip_install(pip_install_name)
       try:
         for module_name in module_names:
           importlib.import_module(module_name)
@@ -49,14 +51,10 @@ def check_and_install_package(module_names, pip_install_name, pre_install_hook =
 # A pre-install step for monai, where we use light-the-torch to install torch more carefully:
 # with light-the-torch, the computation backend is auto-detected from the available hardware preferring CUDA over CPU.
 def monai_pre_install():
-  pip_install_with_cursor('light-the-torch')
-  import light_the_torch
-  wheel_urls = light_the_torch.find_links(['monai'])
-  if not wheel_urls:
-    raise RuntimeError("light-the-torch has could not find suitable PyTorch wheel URLs to install the torch dependencies of MONAI.")
-  for wheel_url in wheel_urls:
-    print("Downloading and installing the following wheel URL obtained via light-the-torch:", wheel_url)
-    pip_install_with_cursor(wheel_url)
+  with BusyCursor():
+    slicer.util.pip_install('light-the-torch')
+    slicer.util._executePythonModule('light_the_torch', ['install', 'monai'])
+
 
 check_and_install_itk = functools.partial(check_and_install_package, ["itk"], "itk")
 check_and_install_pandas = functools.partial(check_and_install_package, ["pandas"], "pandas")


### PR DESCRIPTION
There's an issue with the `light_the_torch` updates that needs to be fixed now. See
- https://discourse.slicer.org/t/error-downloading-pytorch-attributeerror-module-light-the-torch-has-no-attribute-find-links/23928
- https://github.com/pmeier/light-the-torch/issues/41#issuecomment-1155279506

---

unrelated: There was also a spurious import that was added by my IDE accidentally and somehow it got through.
Closes #39