### PR TITLE
STYLE: Update python code with whitespace fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,26 +16,6 @@ format = pylint
 exclude = .git,__pycache__
 
 ignore = \
-  # whitespace after '('
-  E201, \
-  # whitespace before ')'
-  E202, \
-  # whitespace before ','
-  E203, \
-  # multiple spaces after operator
-  E222, \
-  # missing whitespace around operator
-  E225, \
-  # missing whitespace around arithmetic operator
-  E226, \
-  # missing whitespace after ','
-  E231, \
-  # multiple spaces after
-  E241, \
-  # unexpected spaces around keyword / parameter equals
-  E251, \
-  # at least two spaces before inline comment
-  E261, \
   # expected 2 blank lines, found 1
   E302, \
   # too many blank lines

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -23,10 +23,10 @@ class Home(ScriptedLoadableModule):
         self.parent.contributors = ["Ebrahim Ebrahim (Kitware Inc.), Andinet Enquobahrie (Kitware Inc.)"]
         self.parent.helpText = """This is the Home module for LungAIR"""
         self.parent.helpText += self.getModuleDocumentationLink()
-        self.parent.acknowledgementText = """(TODO: put NIH grant number here)""" # replace with organization, grant and thanks.
+        self.parent.acknowledgementText = """(TODO: put NIH grant number here)"""  # replace with organization, grant and thanks.
 
     def getModuleDocumentationLink(self):
-        url = "https://github.com/KitwareMedical/lungair-desktop-application" # Just link to repo for now
+        url = "https://github.com/KitwareMedical/lungair-desktop-application"  # Just link to repo for now
         return f'<p>For more information see the <a href="{url}">code repository</a>.</p>'
 
 
@@ -67,7 +67,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         vboxLayout.addWidget(patientBrowserCollapsible)
         patientBrowserLayout = qt.QFormLayout(patientBrowserCollapsible)
 
-        explanation =  "In lieu of an EHR-linked patient browser,\n"
+        explanation = "In lieu of an EHR-linked patient browser,\n"
         explanation += "we include for now a directory selector.\n"
         explanation += "Images and DICOM files in in the directory\n"
         explanation += "are considered to be chest xrays, while csv\n"
@@ -75,10 +75,10 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         patientBrowserLayout.addRow(qt.QLabel(explanation))
         xrayDirectoryPathLineEdit = ctk.ctkPathLineEdit()
         xrayDirectoryPathLineEdit.filters = ctk.ctkPathLineEdit.Dirs
-        xrayDirectoryPathLineEdit.currentPath = "/home/ebrahim/Desktop/test_patient2" # temporary measure to speed up testing
+        xrayDirectoryPathLineEdit.currentPath = "/home/ebrahim/Desktop/test_patient2"  # temporary measure to speed up testing
         csvDirectoryPathLineEdit = ctk.ctkPathLineEdit()
         csvDirectoryPathLineEdit.filters = ctk.ctkPathLineEdit.Dirs
-        csvDirectoryPathLineEdit.currentPath = "/home/ebrahim/data/eICU/eICU-Original-Data" # temporary measure to speed up testing
+        csvDirectoryPathLineEdit.currentPath = "/home/ebrahim/data/eICU/eICU-Original-Data"  # temporary measure to speed up testing
         patientBrowserLayout.addRow("XRay Image Directory", xrayDirectoryPathLineEdit)
         patientBrowserLayout.addRow("eICU Data Directory", csvDirectoryPathLineEdit)
 
@@ -110,9 +110,9 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         featureComboBox = qt.QComboBox()
         featureComboBox.currentTextChanged.connect(self.onFeatureComboBoxTextChanged)
         advancedLayout.addRow("Feature extraction\nstep to display", featureComboBox)
-        def add_install_button(package_name:str, install_function:str):
+        def add_install_button(package_name: str, install_function: str):
             installButton = qt.QPushButton(f"Check for {package_name} install")
-            installButton.clicked.connect(lambda unused_arg : install_function())
+            installButton.clicked.connect(lambda unused_arg: install_function())
             advancedLayout.addRow(installButton)
         add_install_button("MONAI", dependency_installer.check_and_install_monai)
         add_install_button("ITK-python", dependency_installer.check_and_install_itk)
@@ -151,9 +151,9 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # set up logic
         self.logic.setup(
-            layout_file_path = self.resourcePath("lungair_layout.xml"),
-            model_path = self.resourcePath("PyTorchModels/LungSegmentation/model0018.pth"),
-            backend_to_use = self.backendToUse,
+            layout_file_path=self.resourcePath("lungair_layout.xml"),
+            model_path=self.resourcePath("PyTorchModels/LungSegmentation/model0018.pth"),
+            backend_to_use=self.backendToUse,
         )
 
         # Apply style
@@ -170,11 +170,11 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def onApplicationStartupCompleted(self):
         # Set initial size of the split view
-        half_height = slicer.util.mainWindow().centralWidget().size.height()//2
+        half_height = slicer.util.mainWindow().centralWidget().size.height() // 2
         centralWidgetLayoutFrame = slicer.util.mainWindow().centralWidget().findChild(qt.QFrame, "CentralWidgetLayoutFrame")
         splitter = centralWidgetLayoutFrame.findChild(qt.QSplitter)
         # For the splitter movement to work, we need to first let other events finish processing, hence the timer with timeout of 0
-        qt.QTimer.singleShot(0, lambda : splitter.handle(1).moveSplitter(half_height))
+        qt.QTimer.singleShot(0, lambda: splitter.handle(1).moveSplitter(half_height))
 
     def onLoadPatientClicked(self):
         self.logic.loadXraysFromDirectory(self.xrayDirectoryPathLineEdit.currentPath)
@@ -244,7 +244,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.hideSlicerUI()
 
 
-    def toggleStyle(self,visible):
+    def toggleStyle(self, visible):
         if visible:
             self.applyApplicationStyle()
         else:
@@ -266,14 +266,14 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def applyStyle(self, widgets, styleSheetName):
         stylesheetfile = self.resourcePath(styleSheetName)
-        with open(stylesheetfile,"r") as fh:
+        with open(stylesheetfile, "r") as fh:
             style = fh.read()
             for widget in widgets:
                 widget.styleSheet = style
 
 
 # TODO: move this to an appropriate place
-def tableNodeFromDataFrame(df, editable = False):
+def tableNodeFromDataFrame(df, editable=False):
     """Given a pandas dataframe, return a vtkMRMLTableNode with a copy of the data as strings.
     This is not performant; use on small dataframes only."""
     tableNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
@@ -293,14 +293,14 @@ def tableNodeFromDataFrame(df, editable = False):
 
 
 
-class ClinicalParametersTabWidget(qt.QTabWidget): # TODO move this class to an appropriate place
+class ClinicalParametersTabWidget(qt.QTabWidget):  # TODO move this class to an appropriate place
     def __init__(self):
         super().__init__()
 
         self.patient_table_view = slicer.qMRMLTableView()
         self.patient_table_view.setMRMLScene(slicer.mrmlScene)
         self.addTab(self.patient_table_view, "Patient data")
-        self.patient_table_node = None # vtkMRMLTableNode
+        self.patient_table_node = None  # vtkMRMLTableNode
 
         self.fio2_line_plot = SlicerPlotData("fio2Line")
         self.addTab(self.fio2_line_plot.plot_view, "FiO2 plot")
@@ -310,7 +310,7 @@ class ClinicalParametersTabWidget(qt.QTabWidget): # TODO move this class to an a
     def set_table_node(self, table_node):
         """Set the patient table view to show the given vtkMRMLTableNode."""
         self.patient_table_view.setMRMLTableNode(table_node)
-        self.patient_table_view.setFirstRowLocked(True) # Put the column names in the top header, rather than A,B,...
+        self.patient_table_view.setFirstRowLocked(True)  # Put the column names in the top header, rather than A,B,...
 
     def set_patient_df(self, patient_df):
         """Populate the patient table view with the contents of the given dataframe"""
@@ -331,10 +331,10 @@ class ClinicalParametersTabWidget(qt.QTabWidget): # TODO move this class to an a
         """
 
         self.fio2_line_plot.set_plot_data(
-            data = fio2_data,
-            x_axis_label = "time since unit admission (min)",
-            y_axis_label = "FiO2 (%)",
-            title = "FiO2",
+            data=fio2_data,
+            x_axis_label="time since unit admission (min)",
+            y_axis_label="FiO2 (%)",
+            title="FiO2",
         )
 
     def set_fio2_bar_plot(self, bins, total_times):
@@ -346,13 +346,13 @@ class ClinicalParametersTabWidget(qt.QTabWidget): # TODO move this class to an a
           total_times: array with the total time, in minutes, spent in each bin from bins
         """
         self.fio2_bar_plot.set_plot_data(
-            data = np.array([np.array(bins).mean(axis=1) , total_times]).transpose(),
-            x_axis_label = "FiO2 range (%)",
-            y_axis_label = "Total time (min)",
-            title = "FiO2 times",
+            data=np.array([np.array(bins).mean(axis=1), total_times]).transpose(),
+            x_axis_label="FiO2 range (%)",
+            y_axis_label="Total time (min)",
+            title="FiO2 times",
             legend_label="Time (min)",
-            plot_type = "scatterbar",
-            labels = [f"{start} to {end}" for start, end in bins]
+            plot_type="scatterbar",
+            labels=[f"{start} to {end}" for start, end in bins]
         )
 
 class HomeLogic(ScriptedLoadableModuleLogic):
@@ -365,7 +365,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
-    def exitApplication(self,status=slicer.util.EXIT_SUCCESS, message=None):
+    def exitApplication(self, status=slicer.util.EXIT_SUCCESS, message=None):
         """Exit application.
         If ``status`` is ``slicer.util.EXIT_SUCCESS``, ``message`` is logged using ``logging.info(message)``
         otherwise it is logged using ``logging.error(message)``.
@@ -386,11 +386,11 @@ class HomeLogic(ScriptedLoadableModuleLogic):
         # Set up layout
         # --------------
 
-        with open(layout_file_path,"r") as fh:
+        with open(layout_file_path, "r") as fh:
             layout_text = fh.read()
 
         # built-in layout IDs are all below 100, so we can choose any large random number for this one
-        layoutID=501
+        layoutID = 501
 
         layoutManager = slicer.app.layoutManager()
         layoutManager.layoutLogic().GetLayoutNode().AddLayoutDescription(layoutID, layout_text)
@@ -411,7 +411,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
 
             barWidget = sliceWidget.sliceController().barWidget()
             barWidget.setStyleSheet(f"background-color: #{BAR_WIDGET_COLOR}; color: #FFFFFF;")
-            resetViewButton = [child for child in barWidget.children() if child.name=="FitToWindowToolButton"][0]
+            resetViewButton = [child for child in barWidget.children() if child.name == "FitToWindowToolButton"][0]
             resetViewButton.toolTip = "<p>Reset X-Ray view to fill the viewer.</p>"
 
         self.clinical_parameters_widget = None
@@ -435,7 +435,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
             # This removes the stretch that was added at
             # https://github.com/Slicer/Slicer/blob/d3b8e33a8a2f5a4cb73a0060e34513eb8573c12b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx#L110
             # which is necessary to get the bar widgets to have a consistent appearance
-            barWidget.layout().takeAt(barWidget.layout().count()-1)
+            barWidget.layout().takeAt(barWidget.layout().count() - 1)
 
             for widget in barWidget.children():
                 if not widget.isWidgetType():
@@ -449,7 +449,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
             raise RuntimeError("Unable to find Risk Analysis widget; UI setup has failed.")
 
         self.clinical_parameters_tabWidget = ClinicalParametersTabWidget()
-        self.risk_analysis_tabWidget = qt.QTabWidget() # TODO make this, eventually
+        self.risk_analysis_tabWidget = qt.QTabWidget()  # TODO make this, eventually
         self.clinical_parameters_widget.layout().addWidget(self.clinical_parameters_tabWidget)
         self.risk_analysis_widget.layout().addWidget(self.risk_analysis_tabWidget)
 
@@ -508,23 +508,23 @@ class HomeLogic(ScriptedLoadableModuleLogic):
 
         return True
 
-    def loadXraysFromDirectory(self, dir_path : str):
+    def loadXraysFromDirectory(self, dir_path: str):
         self.xray_collection.clear()
         for item_name in os.listdir(dir_path):
-            item_path = os.path.join(dir_path,item_name)
+            item_path = os.path.join(dir_path, item_name)
             loaded_xrays = xray.load_xrays(item_path, self.seg_model)
-            if len(loaded_xrays)==0:
+            if len(loaded_xrays) == 0:
                 raise RuntimeError("Failed to load xray(s) from path", item_path)
             self.xray_collection.extend(loaded_xrays)
             self.xray_collection.select(loaded_xrays[0].name)
 
-    def selectXrayByName(self, name : str):
+    def selectXrayByName(self, name: str):
         self.xray_collection.select(name)
 
     def segmentSelected(self, backend_to_use):
         self.xray_collection.segment_selected(backend_to_use)
 
-    def loadEICUFromDirectory(self, dir_path : str, schema_dir : str):
+    def loadEICUFromDirectory(self, dir_path: str, schema_dir: str):
         """ As a placeholder to get some EHR data to play with, we use the eICU dataset.
         See https://eicu-crd.mit.edu/about/eicu/
         It's not NICU-focused or even pediatric-focused, but it's something to work with for now.
@@ -534,7 +534,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
           schema_dir : path to the directory that contains table schema text files; see EICU class documentation for details.
         """
         import pandas as pd
-        if not hasattr(self,"eicu") or not self.eicu:
+        if not hasattr(self, "eicu") or not self.eicu:
             from HomeLib.eicu import Eicu
             self.eicu = Eicu(dir_path, schema_dir)
         self.unitstay_id = self.eicu.get_random_unitstay()
@@ -545,7 +545,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
 
         patient_df = self.eicu.get_patient_from_unitstay(self.unitstay_id).to_frame().reset_index()
         patient_df.columns = ["Parameter", "Value"]
-        patient_df = pd.concat([patient_df, pd.DataFrame([{"Parameter":"Average FiO2", "Value":average_fio2}])])
+        patient_df = pd.concat([patient_df, pd.DataFrame([{"Parameter": "Average FiO2", "Value": average_fio2}])])
 
         self.clinical_parameters_tabWidget.set_patient_df(patient_df)
         self.clinical_parameters_tabWidget.set_fio2_line_plot(fio2_data.to_numpy())

--- a/Modules/Scripted/Home/HomeLib/dependency_installer.py
+++ b/Modules/Scripted/Home/HomeLib/dependency_installer.py
@@ -12,7 +12,7 @@ class BusyCursor:
         return False
 
 
-def check_and_install_package(module_names, pip_install_name, pre_install_hook = None):
+def check_and_install_package(module_names, pip_install_name, pre_install_hook=None):
     """
     Check if given module can be imported, and if not then prompt user to possibly attempt an install.
 

--- a/Modules/Scripted/Home/HomeLib/eicu.py
+++ b/Modules/Scripted/Home/HomeLib/eicu.py
@@ -2,11 +2,11 @@ import numpy as np
 import pandas as pd
 import os
 
-DTYPE_STRING_MAPPING = { # Map schema dtype string to pandas dtype string
-    'int4' : 'int32', # note that int4 means 4 *bytes* not *bits*
-    'int2' : 'int16',
-    'varchar' : 'str',
-    'numeric' : 'float32'
+DTYPE_STRING_MAPPING = {  # Map schema dtype string to pandas dtype string
+    'int4': 'int32',  # note that int4 means 4 *bytes* not *bits*
+    'int2': 'int16',
+    'varchar': 'str',
+    'numeric': 'float32'
 }
 
 def get_dtype_dict(pasted_table_path):
@@ -22,7 +22,7 @@ def get_dtype_dict(pasted_table_path):
 
 class Eicu:
 
-    def __init__(self, eICU_dir:str, schema_dir:str):
+    def __init__(self, eICU_dir: str, schema_dir: str):
         """Create object to interface with EICU dataset. This reads the tables into memory.
 
         Args:
@@ -33,23 +33,23 @@ class Eicu:
 
         # Load patient table
         self.patient_df = pd.read_csv(
-            os.path.join(eICU_dir,"patient.csv.gz"),
-            dtype = get_dtype_dict(os.path.join(schema_dir, "patient.txt")),
+            os.path.join(eICU_dir, "patient.csv.gz"),
+            dtype=get_dtype_dict(os.path.join(schema_dir, "patient.txt")),
             index_col='patientunitstayid',
         )
 
         # Load respiratory care table
         dtype_dict = get_dtype_dict(os.path.join(schema_dir, "respiratoryCareSchema.txt"))
-        dtype_dict['apneaparms'] = 'str' # Special case because this column is misspelled in csv vs schema
+        dtype_dict['apneaparms'] = 'str'  # Special case because this column is misspelled in csv vs schema
         self.respiratory_care_df = pd.read_csv(
-            os.path.join(eICU_dir,"respiratoryCare.csv.gz"),
-            dtype = dtype_dict,
+            os.path.join(eICU_dir, "respiratoryCare.csv.gz"),
+            dtype=dtype_dict,
         )
 
         # Load respiratory charting table
         self.respiratory_charting_df = pd.read_csv(
-            os.path.join(eICU_dir,"respiratoryCharting_SUBSET.csv"),
-            dtype = get_dtype_dict(os.path.join(schema_dir, "respiratoryCharting.txt"))
+            os.path.join(eICU_dir, "respiratoryCharting_SUBSET.csv"),
+            dtype=get_dtype_dict(os.path.join(schema_dir, "respiratoryCharting.txt"))
         )
 
         self.fio2_df = None
@@ -63,7 +63,7 @@ class Eicu:
             ]
 
             # add a column that has a float version of the FiO2 value
-            self.fio2_df = fio2_df.assign(respchartvalue_float = fio2_df['respchartvalue'].apply(lambda x : x.strip('%')).astype('float32'))
+            self.fio2_df = fio2_df.assign(respchartvalue_float=fio2_df['respchartvalue'].apply(lambda x: x.strip('%')).astype('float32'))
         return self.fio2_df
 
     def get_random_unitstay(self) -> np.int32:
@@ -72,23 +72,23 @@ class Eicu:
         by providing a random unit stay ID that we can pretend is the "loaded patient stay" in the application.
         """
         fio2_df = self.get_fio2_df()
-        fio2_index = np.random.randint(0,len(fio2_df))
+        fio2_index = np.random.randint(0, len(fio2_df))
         return fio2_df.iloc[fio2_index]['patientunitstayid']
 
-    def get_patient_from_unitstay(self, unitstay_id:str) -> pd.core.series.Series:
+    def get_patient_from_unitstay(self, unitstay_id: str) -> pd.core.series.Series:
         """Return series of patient data for the patient associated to the given unit stay ID."""
         return self.patient_df.loc[unitstay_id]
 
-    def get_patient_id_from_unitstay(self, unitstay_id:str) -> str:
+    def get_patient_id_from_unitstay(self, unitstay_id: str) -> str:
         return self.get_patient_from_unitstay(unitstay_id)['uniquepid']
 
-    def get_number_of_unit_stays(self, patient_id:str):
-        return len(self.patient_df[self.patient_df['uniquepid']==patient_id])
+    def get_number_of_unit_stays(self, patient_id: str):
+        return len(self.patient_df[self.patient_df['uniquepid'] == patient_id])
 
-    def get_number_of_hospital_admissions(self, patient_id:str):
-        len(self.patient_df[self.patient_df['uniquepid']==patient_id]['patienthealthsystemstayid'].unique())
+    def get_number_of_hospital_admissions(self, patient_id: str):
+        len(self.patient_df[self.patient_df['uniquepid'] == patient_id]['patienthealthsystemstayid'].unique())
 
-    def process_fio2_data_for_unitstay(self, unitstay_id:str):
+    def process_fio2_data_for_unitstay(self, unitstay_id: str):
         """Given a unit stay ID, this will lookup all the FiO2 data for that unit stay and return some useful information about it.
 
         We are still experimenting with different ways to aggregate these clinical parameters for viewing and for predictive models.
@@ -106,22 +106,22 @@ class Eicu:
         fio2_for_unitstay = fio2_df[fio2_df['patientunitstayid'] == unitstay_id]
         fio2_data = fio2_for_unitstay[['respchartoffset', 'respchartvalue_float']].sort_values(by='respchartoffset')
 
-        fio2_data_with_deltas = fio2_data.assign(delta_t = fio2_data['respchartoffset'].diff())
-        fio2_data_with_deltas = fio2_data_with_deltas.assign(val_shifted = fio2_data_with_deltas['respchartvalue_float'].shift(1))
+        fio2_data_with_deltas = fio2_data.assign(delta_t=fio2_data['respchartoffset'].diff())
+        fio2_data_with_deltas = fio2_data_with_deltas.assign(val_shifted=fio2_data_with_deltas['respchartvalue_float'].shift(1))
         total_fio2_time = fio2_data_with_deltas['delta_t'].sum()
-        if (total_fio2_time<=0.): # It should be possible to have total_fio2_time be 0, if there is just one fio2 entry (so there are no delta_t's)
-            if len(fio2_for_unitstay)>1: # If that is not what happened, we need to fix this code because that's a case I haven't thought about
+        if (total_fio2_time <= 0.):  # It should be possible to have total_fio2_time be 0, if there is just one fio2 entry (so there are no delta_t's)
+            if len(fio2_for_unitstay) > 1:  # If that is not what happened, we need to fix this code because that's a case I haven't thought about
                 raise Exception(f"Got total time FiO2 time of 0 when trying to integrate, but there is more than one FiO2 entry. Unit stay ID: {unitstay_id}.")
-            if len(fio2_for_unitstay)<1:
+            if len(fio2_for_unitstay) < 1:
                 raise ValueError(f"Unit stay id {unitstay_id} has no associated FiO2 data.")
             average_fio2 = fio2_for_unitstay.iloc[0]['respchartvalue_float']
         else:
             # This is basically an integral to compute the average value:
-            average_fio2 = (fio2_data_with_deltas['val_shifted']*fio2_data_with_deltas['delta_t']).sum() / total_fio2_time
+            average_fio2 = (fio2_data_with_deltas['val_shifted'] * fio2_data_with_deltas['delta_t']).sum() / total_fio2_time
 
         # Compute total time spent within each FiO2 value bin
-        bins = [[start, start+10] for start in range(0,100,10)]
-        total_times = [ fio2_data_with_deltas['delta_t'][(fio2_data_with_deltas['val_shifted']>=start) & (fio2_data_with_deltas['val_shifted']<end)].sum()
-                        for start,end in bins ]
+        bins = [[start, start + 10] for start in range(0, 100, 10)]
+        total_times = [fio2_data_with_deltas['delta_t'][(fio2_data_with_deltas['val_shifted'] >= start) & (fio2_data_with_deltas['val_shifted'] < end)].sum()
+                       for start, end in bins]
 
         return fio2_data, average_fio2, bins, total_times

--- a/Modules/Scripted/Home/HomeLib/image_utils.py
+++ b/Modules/Scripted/Home/HomeLib/image_utils.py
@@ -7,7 +7,7 @@ from vtk.util.numpy_support import get_vtk_array_type, get_numpy_array_type
 # slicer.util.updateVolumeFromArray and slicer.util.updateSegmentBinaryLabelmapFromArray
 
 
-def create_image_data_from_numpy_array(array, oriented : bool, copy = True):
+def create_image_data_from_numpy_array(array, oriented: bool, copy=True):
     """Create a vtk image data object from a numpy array.
     A 2D numpy array will be turned into a single-axial-slice vtkImageData.
 
@@ -23,7 +23,7 @@ def create_image_data_from_numpy_array(array, oriented : bool, copy = True):
     # See the following for hints on how this works:
     # https://github.com/Kitware/VTK/blob/master/Wrapping/Python/vtkmodules/util/numpy_support.py
 
-    if (len(array.shape)!=2):
+    if (len(array.shape) != 2):
         raise ValueError(f"2D array was expected; got {len(array.shape)}D array")
 
     # Get type, e.g. vtk.VTK_FLOAT
@@ -63,7 +63,7 @@ def create_image_data_from_numpy_array(array, oriented : bool, copy = True):
     return imageData
 
 
-def create_volume_node_from_numpy_array(array, ijk_to_ras_directions, node_name : str):
+def create_volume_node_from_numpy_array(array, ijk_to_ras_directions, node_name: str):
     """Create a volume node and add it to the scene.
 
     Args:
@@ -74,22 +74,22 @@ def create_volume_node_from_numpy_array(array, ijk_to_ras_directions, node_name 
     Returns: the added vtkMRMLScalarVolumeNode
     """
 
-    imageData = create_image_data_from_numpy_array(array, oriented = False)
+    imageData = create_image_data_from_numpy_array(array, oriented=False)
 
     # Create and add a volume node to the scene, setting our vtkImageData to be its underlying image data
     volumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", node_name)
-    volumeNode.SetOrigin([0.,0.,0.])
-    volumeNode.SetSpacing([1.,1.,1.])
+    volumeNode.SetOrigin([0., 0., 0.])
+    volumeNode.SetSpacing([1., 1., 1.])
     volumeNode.SetIJKToRASDirections(ijk_to_ras_directions)
     volumeNode.SetAndObserveImageData(imageData)
     volumeNode.CreateDefaultDisplayNodes()
     defaultStorageNode = volumeNode.CreateDefaultStorageNode()
-    defaultStorageNode.UnRegister(None) # Needed to avoid memory leak. See https://github.com/Slicer/Slicer/issues/6099
+    defaultStorageNode.UnRegister(None)  # Needed to avoid memory leak. See https://github.com/Slicer/Slicer/issues/6099
 
     return volumeNode
 
 
-def create_segmentation_node_from_numpy_array(array, class_names : dict, node_name : str, vol_node):
+def create_segmentation_node_from_numpy_array(array, class_names: dict, node_name: str, vol_node):
     """Create a segmentation node and add it to the scene.
     Args:
       array: a contiguous 2D numpy array consisting of discrete class labels
@@ -100,15 +100,15 @@ def create_segmentation_node_from_numpy_array(array, class_names : dict, node_na
 
     Returns: the added vtkMRMLSegmentationNode
     """
-    ijk_to_ras_directions = np.zeros((3,3))
+    ijk_to_ras_directions = np.zeros((3, 3))
     vol_node.GetIJKToRASDirections(ijk_to_ras_directions)
 
     segNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode", node_name)
     segNode.SetReferenceImageGeometryParameterFromVolumeNode(vol_node)
     segNode.CreateDefaultDisplayNodes()
     for class_label in class_names.keys():
-        binary_labelmap_array = (array==class_label).astype('int8')
-        orientedImageData = create_image_data_from_numpy_array(binary_labelmap_array, oriented = True)
+        binary_labelmap_array = (array == class_label).astype('int8')
+        orientedImageData = create_image_data_from_numpy_array(binary_labelmap_array, oriented=True)
         orientedImageData.SetDirections(ijk_to_ras_directions)
         segNode.AddSegmentFromBinaryLabelmapRepresentation(orientedImageData, class_names[class_label])
     return segNode

--- a/Modules/Scripted/Home/HomeLib/plots.py
+++ b/Modules/Scripted/Home/HomeLib/plots.py
@@ -3,10 +3,10 @@ from .constants import *
 
 
 PLOT_TYPES = {
-    "line" : slicer.vtkMRMLPlotSeriesNode.PlotTypeLine,
-    "bar" : slicer.vtkMRMLPlotSeriesNode.PlotTypeBar,
-    "scatter" : slicer.vtkMRMLPlotSeriesNode.PlotTypeScatter,
-    "scatterbar" : slicer.vtkMRMLPlotSeriesNode.PlotTypeScatterBar,
+    "line": slicer.vtkMRMLPlotSeriesNode.PlotTypeLine,
+    "bar": slicer.vtkMRMLPlotSeriesNode.PlotTypeBar,
+    "scatter": slicer.vtkMRMLPlotSeriesNode.PlotTypeScatter,
+    "scatterbar": slicer.vtkMRMLPlotSeriesNode.PlotTypeScatterBar,
 }
 
 def createPlotView():
@@ -19,15 +19,15 @@ def createPlotView():
     fit_plot_tool_button.clicked.connect(lambda: plot_view.fitToContent())
 
     # Put the QToolButton in the top right corner of the plot
-    assert(plot_view.layout() is None) # failure here indicates a slicer change in which plot views gained layouts, which we should take care not to replace
+    assert(plot_view.layout() is None)  # failure here indicates a slicer change in which plot views gained layouts, which we should take care not to replace
     plot_view.setLayout(qt.QHBoxLayout())
-    plot_view.layout().insertWidget(1,fit_plot_tool_button,0,qt.Qt.AlignTop)
-    spacer = qt.QSpacerItem(20,20,qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding)
-    plot_view.layout().insertItem(0,spacer)
-    plot_view.layout().margin=0
+    plot_view.layout().insertWidget(1, fit_plot_tool_button, 0, qt.Qt.AlignTop)
+    spacer = qt.QSpacerItem(20, 20, qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding)
+    plot_view.layout().insertItem(0, spacer)
+    plot_view.layout().margin = 0
 
     # Give it a nice appearance
-    fit_plot_tool_button.setIconSize(qt.QSize(10,10))
+    fit_plot_tool_button.setIconSize(qt.QSize(10, 10))
     fit_plot_tool_button.setIcon(qt.QIcon(":Icons/SlicesFitToWindow.png"))
     fit_plot_tool_button.setStyleSheet(f"background-color:#{BAR_WIDGET_COLOR};")
     fit_plot_tool_button.setAutoRaise(True)
@@ -43,13 +43,13 @@ class SlicerPlotData:
     # A plot view node we will keep empty in order to have a way of displaying no plot
     empty_plot_view_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotViewNode", "SlicerPlotDataEmptyPlotViewNode")
 
-    def __init__(self, name:str):
+    def __init__(self, name: str):
         """Create SlicerPlotData, making a qMRMLPlotView and a vtkMRMLPlotViewNode with the given name."""
         self.name = name
         self.plot_view = createPlotView()
-        self.plot_view_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotViewNode", name+"PlotView")
+        self.plot_view_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotViewNode", name + "PlotView")
         self.plot_view.setMRMLPlotViewNode(self.plot_view_node)
-        self.plot_nodes = {} # chart, table, and series; see the parameter "nodes" in the doc of slicer.util.plot
+        self.plot_nodes = {}  # chart, table, and series; see the parameter "nodes" in the doc of slicer.util.plot
 
 
     def set_plot_data(self, data, x_axis_label=None, y_axis_label=None, title=None, legend_label=None, plot_type="line", labels=None):
@@ -69,7 +69,7 @@ class SlicerPlotData:
         if title is None: title = self.name
         if legend_label is None: legend_label = title
 
-        if len(data.shape)!=2 or data.shape[1]!=2:
+        if len(data.shape) != 2 or data.shape[1] != 2:
             raise ValueError(f"data was expected to be a numpy array of shape (N,2), got {tuple(data.shape)}")
 
         # Here we avoid changing plots while they are associated to a plot view.
@@ -83,16 +83,16 @@ class SlicerPlotData:
             columnNames = None
 
         plot_chart_node = slicer.util.plot(
-            data, 0, show = False,
-            title = title,
-            columnNames = columnNames,
-            nodes = self.plot_nodes
+            data, 0, show=False,
+            title=title,
+            columnNames=columnNames,
+            nodes=self.plot_nodes
         )
         plot_chart_node.SetXAxisTitle(x_axis_label)
         if y_axis_label is not None:
             plot_chart_node.SetYAxisTitle(y_axis_label)
         assert(len(self.plot_nodes["series"]) == 1)
-        self.plot_nodes["series"][0].SetName(legend_label) # This text is displayed in the legend
+        self.plot_nodes["series"][0].SetName(legend_label)  # This text is displayed in the legend
         self.plot_nodes["series"][0].SetPlotType(PLOT_TYPES[plot_type])
         self.plot_view_node.SetPlotChartNodeID(plot_chart_node.GetID())
 

--- a/Modules/Scripted/Home/HomeLib/segmentation_model.py
+++ b/Modules/Scripted/Home/HomeLib/segmentation_model.py
@@ -51,11 +51,11 @@ class SegmentationModel:
 
             # Transforms a given image to the input format expected by the segmentation network
             self.transform = monai.transforms.Compose([
-                monai.transforms.CastToType(dtype=np.float32), # TODO dtype should have been included in the model_dict
+                monai.transforms.CastToType(dtype=np.float32),  # TODO dtype should have been included in the model_dict
                 monai.transforms.AddChannel(),
                 monai.transforms.Resize(
-                    spatial_size=(self.image_size,self.image_size),
-                    mode = 'bilinear',
+                    spatial_size=(self.image_size, self.image_size),
+                    mode='bilinear',
                     align_corners=False
                 ),
                 monai.transforms.ToTensor()
@@ -97,12 +97,12 @@ class SegmentationModel:
             seg_net_output = self.seg_net(img_input.unsqueeze(0))[0]
 
             # assumption at the moment is that we have 2-channel image out (i.e. purely binary segmentation was done)
-            assert(seg_net_output.shape[0]==2)
+            assert(seg_net_output.shape[0] == 2)
 
             _, max_indices = seg_net_output.max(dim=0)
-            seg_mask = (max_indices==1).type(torch.uint8)
+            seg_mask = (max_indices == 1).type(torch.uint8)
 
-            model_to_img_matrix = np.diag(np.array(img.shape)/self.image_size)
+            model_to_img_matrix = np.diag(np.array(img.shape) / self.image_size)
 
             # TODO skipping post processing because post processing causes crash due to ITK
             # python issues seg_processed = self.seg_post_process(seg_mask)


### PR DESCRIPTION
_This commit was adapted from Slicer/Slicer@5b0fc5cec_

This fixes all remaining pycodestyle E2 whitespace error codes.

Bulk of updates performed using autopep8 CLI
with the following command:

  autopep8 --in-place --select E201,E202,E203,E222,E225,E226,E231,E241,E251,E261 $(git ls-files '*.py')

See https://github.com/hhatto/autopep8#readme

References:

* Whitespace after '(' See https://www.flake8rules.com/rules/E201.html

* Whitespace before ')' See https://www.flake8rules.com/rules/E202.html

* Whitespace before ':' See https://www.flake8rules.com/rules/E203.html

* Multiple spaces after operator See https://www.flake8rules.com/rules/E222.html

* Missing whitespace around operator See https://www.flake8rules.com/rules/E225.html

* Missing whitespace around arithmetic operator See https://www.flake8rules.com/rules/E226.html

* Missing whitespace after ',', ';', or ':' See https://www.flake8rules.com/rules/E231.html

* Multiple spaces after ',' See https://www.flake8rules.com/rules/E241.html

* Unexpected spaces around keyword / parameter equals See https://www.flake8rules.com/rules/E251.html

* At least two spaces before inline comment See https://www.flake8rules.com/rules/E261.html