### PR TITLE
STYLE: Remove unused python imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -30,8 +30,6 @@ ignore = \
   E701, \
   # ambiguous variable name 'l'
   E741, \
-  # imported but unused
-  F401, \
   # import shadowed by loop variable
   F402, \
   # 'from module import *' used; unable to detect undefined names

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -1,4 +1,3 @@
-from genericpath import exists
 import os
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
@@ -489,7 +488,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
         # Check for eicu dependencies
         # ------------------------
         try:
-            from HomeLib.eicu import Eicu
+            from HomeLib.eicu import Eicu  # noqa: F401
         except Exception as e:
             qt.QMessageBox.critical(
                 slicer.util.mainWindow(), "Error importing eICU interface class",

--- a/Modules/Scripted/Home/HomeLib/xray.py
+++ b/Modules/Scripted/Home/HomeLib/xray.py
@@ -1,4 +1,3 @@
-from email.mime import image
 import logging
 import os
 import numpy as np


### PR DESCRIPTION
Summary of `Home` module updates:

* Remove `genericpath.exists` unused import originally introduced in c34246e02 (display ehr data and plots in the application)

* Mark `Eicu` import as a valid exception since the purpose of the import is to test for the availability of the package.

Summary of `HomeLib/xray` module updates:

* Remove `email.mime.image` unused import originally introduced in 5030239e7 (separate creation of volume nodes out of Xray ctor)

References:
    
* Module imported but unused
  See https://www.flake8rules.com/rules/F401.html