### PR TITLE
STYLE: Update python code with blank line fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,14 +16,6 @@ format = pylint
 exclude = .git,__pycache__
 
 ignore = \
-  # expected 2 blank lines, found 1
-  E302, \
-  # too many blank lines
-  E303, \
-  # expected 2 blank lines after class or function definition
-  E305, \
-  # expected 1 blank line before a nested definition
-  E306, \
   # multiple imports on one line
   E401, \
   # multiple statements on one line (colon)

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -10,6 +10,7 @@ from HomeLib.plots import *
 import HomeLib.xray as xray
 from HomeLib.constants import *
 
+
 class Home(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
@@ -38,7 +39,6 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def __init__(self, parent):
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)
-
 
     def setup(self):
         try:
@@ -110,6 +110,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         featureComboBox = qt.QComboBox()
         featureComboBox.currentTextChanged.connect(self.onFeatureComboBoxTextChanged)
         advancedLayout.addRow("Feature extraction\nstep to display", featureComboBox)
+
         def add_install_button(package_name: str, install_function: str):
             installButton = qt.QPushButton(f"Check for {package_name} install")
             installButton.clicked.connect(lambda unused_arg: install_function())
@@ -124,6 +125,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             SegmentationModel.ModelSource.LOCAL_DEPLOY.value,
             SegmentationModel.ModelSource.DOCKER_DEPLOY.value,
         ])
+
         def backendChanged(index):
             self.backendToUse = SegmentationModel.ModelSource(backendComboBox.currentText)
         backendComboBox.currentIndexChanged.connect(backendChanged)
@@ -141,7 +143,6 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.xrayDirectoryPathLineEdit = xrayDirectoryPathLineEdit
         self.csvDirectoryPathLineEdit = csvDirectoryPathLineEdit
         self.xrayListWidget = xrayListWidget
-
 
         # Add custom toolbar with a settings button and then hide various Slicer UI elements
         self.modifyWindowUI()
@@ -196,7 +197,6 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def onSegmentSelectedClicked(self):
         self.logic.segmentSelected(self.backendToUse)
 
-
     def hideSlicerUI(self):
         slicer.util.setDataProbeVisible(False)
         slicer.util.setMenuBarsVisible(False)
@@ -220,8 +220,6 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         slicer.util.setPythonConsoleVisible(True)
         slicer.util.setToolbarsVisible(True)
 
-
-
     def modifyWindowUI(self):
         slicer.util.setModuleHelpSectionVisible(False)
 
@@ -243,7 +241,6 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.settingsAction.triggered.connect(self.raiseSettings)
         self.hideSlicerUI()
 
-
     def toggleStyle(self, visible):
         if visible:
             self.applyApplicationStyle()
@@ -262,7 +259,6 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def applyApplicationStyle(self):
         # Style
         self.applyStyle([slicer.app], 'Home.qss')
-
 
     def applyStyle(self, widgets, styleSheetName):
         stylesheetfile = self.resourcePath(styleSheetName)
@@ -290,7 +286,6 @@ def tableNodeFromDataFrame(df, editable=False):
 
     tableNode.SetLocked(not editable)
     return tableNode
-
 
 
 class ClinicalParametersTabWidget(qt.QTabWidget):  # TODO move this class to an appropriate place
@@ -354,6 +349,7 @@ class ClinicalParametersTabWidget(qt.QTabWidget):  # TODO move this class to an 
             plot_type="scatterbar",
             labels=[f"{start} to {end}" for start, end in bins]
         )
+
 
 class HomeLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
@@ -453,7 +449,6 @@ class HomeLogic(ScriptedLoadableModuleLogic):
         self.clinical_parameters_widget.layout().addWidget(self.clinical_parameters_tabWidget)
         self.risk_analysis_widget.layout().addWidget(self.risk_analysis_tabWidget)
 
-
         # ------------------------
         # Set up workspace directory
         # ------------------------
@@ -505,7 +500,6 @@ class HomeLogic(ScriptedLoadableModuleLogic):
 
         slicer.util.mainWindow().pythonConsole().setStyleSheet(f"background-color: #FFFFFF")
 
-
         return True
 
     def loadXraysFromDirectory(self, dir_path: str):
@@ -550,6 +544,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
         self.clinical_parameters_tabWidget.set_patient_df(patient_df)
         self.clinical_parameters_tabWidget.set_fio2_line_plot(fio2_data.to_numpy())
         self.clinical_parameters_tabWidget.set_fio2_bar_plot(bins, total_times)
+
 
 class HomeTest(ScriptedLoadableModuleTest):
     """

--- a/Modules/Scripted/Home/HomeLib/eicu.py
+++ b/Modules/Scripted/Home/HomeLib/eicu.py
@@ -9,6 +9,7 @@ DTYPE_STRING_MAPPING = {  # Map schema dtype string to pandas dtype string
     'numeric': 'float32'
 }
 
+
 def get_dtype_dict(pasted_table_path):
     """Table schemas can be copied into text files from https://mit-lcp.github.io/eicu-schema-spy/index.html"""
     dtype_dict = {}
@@ -19,6 +20,7 @@ def get_dtype_dict(pasted_table_path):
                 raise KeyError(f"Please add an entry for {dtype_string} to DTYPE_STRING_MAPPING")
             dtype_dict[column_name] = DTYPE_STRING_MAPPING[dtype_string]
     return dtype_dict
+
 
 class Eicu:
 

--- a/Modules/Scripted/Home/HomeLib/plots.py
+++ b/Modules/Scripted/Home/HomeLib/plots.py
@@ -9,6 +9,7 @@ PLOT_TYPES = {
     "scatterbar": slicer.vtkMRMLPlotSeriesNode.PlotTypeScatterBar,
 }
 
+
 def createPlotView():
     """Create and return a qMRMLPlotView widget.
     It is associated to the main scene, and it also gets a button for fitToContent."""
@@ -50,7 +51,6 @@ class SlicerPlotData:
         self.plot_view_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotViewNode", name + "PlotView")
         self.plot_view.setMRMLPlotViewNode(self.plot_view_node)
         self.plot_nodes = {}  # chart, table, and series; see the parameter "nodes" in the doc of slicer.util.plot
-
 
     def set_plot_data(self, data, x_axis_label=None, y_axis_label=None, title=None, legend_label=None, plot_type="line", labels=None):
         """

--- a/Modules/Scripted/Home/HomeLib/segmentation_post_processing.py
+++ b/Modules/Scripted/Home/HomeLib/segmentation_post_processing.py
@@ -4,6 +4,7 @@ import numpy as np
 import torch
 from collections import OrderedDict
 
+
 class SegmentationPostProcessing():
     """
     Post-processing callable that remembers some intermediate steps.

--- a/Modules/Scripted/Home/HomeLib/xray.py
+++ b/Modules/Scripted/Home/HomeLib/xray.py
@@ -6,6 +6,7 @@ import slicer
 import vtk
 from .image_utils import create_segmentation_node_from_numpy_array
 
+
 def create_linear_transform_node_from_matrix(matrix, node_name):
     """Given a 3D affine transform as a 4x4 matrix, create a vtkMRMLTransformNode in the scene return it."""
     vtk_matrix = slicer.util.vtkMatrixFromArray(matrix)
@@ -13,6 +14,7 @@ def create_linear_transform_node_from_matrix(matrix, node_name):
     transform_node.SetName(node_name)
     transform_node.SetAndObserveMatrixTransformToParent(vtk_matrix)
     return transform_node
+
 
 def create_axial_to_coronal_transform_node():
     axial_to_coronal_np_matrix = np.array([
@@ -23,6 +25,7 @@ def create_axial_to_coronal_transform_node():
     ])
     return create_linear_transform_node_from_matrix(axial_to_coronal_np_matrix, "axial slice to coronal slice")
 
+
 def create_coronal_plane_transform_node_from_2x2(matrix, node_name):
     """Given a 2D linear transform as a 2x2 matrix, create a transform node that carries out the transform within each coronal slice
     The vtkMRMLTransformNode is added to the scene and returned."""
@@ -31,6 +34,7 @@ def create_coronal_plane_transform_node_from_2x2(matrix, node_name):
     affine_transform = np.identity(4)
     affine_transform[np.ix_([2, 0], [2, 0])] = matrix
     return create_linear_transform_node_from_matrix(affine_transform, node_name)
+
 
 def load_dicom_dir(dicomDataDir, pluginName, validate_dict=None, validate_mode=None, quiet=True):
     """Load from a DICOM directory and return a list of the loaded nodes.
@@ -50,6 +54,7 @@ def load_dicom_dir(dicomDataDir, pluginName, validate_dict=None, validate_mode=N
         raise ValueError("Please specify a validate_dict.")
 
     loadedNodes = []
+
     @vtk.calldata_type(vtk.VTK_OBJECT)
     def onNodeAdded(caller, event, calldata):
         node = calldata
@@ -106,12 +111,14 @@ def load_dicom_dir(dicomDataDir, pluginName, validate_dict=None, validate_mode=N
     slicer.mrmlScene.RemoveObserver(sceneObserverTag)
     return loadedNodes
 
+
 # The DICOM validation function that we will use for NICU chest x-rays
 validate_nicu_cxr = {
     "0018,5101": ["AP", "PA"],  # view position
     "0008,0060": ["RG", "DX", "CR"],  # modality
     "0018,0015": ["CHEST"],  # body part examined
 }
+
 
 def load_xrays(path: str, seg_model, image_format=None):
     """
@@ -144,7 +151,6 @@ def load_xrays(path: str, seg_model, image_format=None):
         return loaded_xrays
     else:
         raise ValueError("Unrecognized image_format.")
-
 
 
 class Xray:
@@ -360,7 +366,6 @@ class XrayDisplayManager:
         self.xray_view_node = self.xray_slice_view.mrmlSliceNode()
         self.xray_features_view_node = self.xray_features_slice_view.mrmlSliceNode()
 
-
     def show_xray(self, xray: Xray):
         """Show the given Xray image in the xray display views"""
         self.xray_composite_node.SetBackgroundVolumeID(xray.volume_node.GetID())
@@ -390,6 +395,7 @@ def shItem_has_volume_node_descendant(item_id):
             return True
     return False
 
+
 def prune_unused_subjects():
     """Delete any unused top-level subjects from the subject hierarchy.
     Here "unused" means subjects that contain no volume nodes under them."""
@@ -400,6 +406,7 @@ def prune_unused_subjects():
         top_level_child = top_level_children.GetId(i)
         if shNode.GetItemLevel(top_level_child) == "Patient" and not shItem_has_volume_node_descendant(top_level_child):
             shNode.RemoveItem(top_level_child)
+
 
 class XrayCollection(dict):
     """A mapping from xray names to xray objects, with some useful xray-specific functionality."""


### PR DESCRIPTION
This fixes all remaining pycodestyle E3 line error codes.

Bulk of updates performed using autopep8 CLI
with the following command:

```
autopep8 --in-place --select E302,E303,E305,E306 $(git ls-files '*.py')
```

See https://github.com/hhatto/autopep8#readme

References:

* Expected 2 blank lines, found 0 
  See https://www.flake8rules.com/rules/E302.html

* Too many blank lines (3)
  See https://www.flake8rules.com/rules/E303.html

* Expected 2 blank lines after end of function or class
  See https://www.flake8rules.com/rules/E305.html

* Expected 1 blank line before a nested definition
  See https://www.flake8rules.com/rules/E306.html