### PR TITLE
Upgrade python syntax to 3.9 and newer & update pre-commit to enforce latest python syntax using pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear]
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.1.0
+  hooks:
+  - id: pyupgrade
+    args: [--py39-plus]

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -266,7 +266,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def applyStyle(self, widgets, styleSheetName):
         stylesheetfile = self.resourcePath(styleSheetName)
-        with open(stylesheetfile, "r") as fh:
+        with open(stylesheetfile) as fh:
             style = fh.read()
             for widget in widgets:
                 widget.styleSheet = style
@@ -386,7 +386,7 @@ class HomeLogic(ScriptedLoadableModuleLogic):
         # Set up layout
         # --------------
 
-        with open(layout_file_path, "r") as fh:
+        with open(layout_file_path) as fh:
             layout_text = fh.read()
 
         # built-in layout IDs are all below 100, so we can choose any large random number for this one
@@ -594,6 +594,6 @@ class HomeTest(ScriptedLoadableModuleTest):
 # Class for avoiding python error that is caused by the method SegmentEditor::setup
 # http://issues.slicer.org/view.php?id=3871
 #
-class HomeFileWriter(object):
+class HomeFileWriter:
     def __init__(self, parent):
         pass

--- a/Modules/Scripted/Home/HomeLib/segmentation_model.py
+++ b/Modules/Scripted/Home/HomeLib/segmentation_model.py
@@ -18,7 +18,7 @@ from .segmentation_post_processing import SegmentationPostProcessing
 class SegmentationModel:
     class NoValue(enum.Enum):
         def __repr__(self):
-            return '<%s.%s>' % (self.__class__.__name__, self.name)
+            return f'<{self.__class__.__name__}.{self.name}>'
 
     class ModelSource(NoValue):
         LOCAL_WEIGHTS = 'Locally saved model weights, without MONAI deploy'


### PR DESCRIPTION
_This pull-request was adapted from Slicer/Slicer@a4ea79909 and Slicer/Slicer@e62a3e557a._

Upgrade python syntax to 3.9 and newer

By adding `pyupgrade` to the pre-commit configuration, it enables the following:

* GitHub Action report: Suggested changes are reported in the error log associated with the pre-commit GitHub Action workflow.

* Consolidated local pre-commit checks and updates by running:

  ```
  PythonSlicer -m pip install pyupgrade
  PythonSlicer -m pre_commit run --all-files
  ```